### PR TITLE
Improve core credits in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ To play Spacewar on your Pocket, please use [this guide](https://www.analogue.co
 ## Credits
 This core is released under the [MIT License](https://github.com/spacemen3/PDP-1/blob/main/LICENSE).
 
-The CPU used in this core is credited to https://github.com/MiSTer-devel/PDP1_MiSTer
+This is a port of the [PDP1_MiSTer](https://github.com/MiSTer-devel/PDP1_MiSTer/) core designed by [Hrvoje Čavrak](https://github.com/hrvach) for the [MiSTer FPGA platform](https://mister-devel.github.io/MkDocs_MiSTer/).


### PR DESCRIPTION
The current core credits only give credit to the repo and not the developer (@hrvach) by name, also added a link to the MiSTer FPGA platform for proper context. I used the word port instead as the vast majority of what makes the PDP1 tick is it's CPU anyways, and there is more than the CPU code in this repo. I really like the changes you made to the colors and the option to load colors externally, very cool idea. :)